### PR TITLE
Upgrade to 1.3.0-beta2

### DIFF
--- a/src/DotQuery.Core/project.json
+++ b/src/DotQuery.Core/project.json
@@ -1,6 +1,6 @@
 {
   "title": "DotQuery.Core",
-  "version": "1.3.0-beta",
+  "version": "1.3.0-beta2",
   "description": "Core libs of DotQuery, a lightweight query result caching framework for .NET",
   "packOptions": {
     "owners": [ "karldodd" ],
@@ -16,15 +16,26 @@
     "xmlDoc": true
   },
   "frameworks": {
+    "net451": {
+      "dependencies": {
+        "System.Runtime": "4.0.10",
+        "System.Collections": "4.0.0",
+        "System.Threading": "4.0.0",
+        "System.Threading.Tasks": "4.0.0",
+        "System.Linq": "4.0.0"
+      }
+    },
     "netstandard1.0": {
       "imports": "dnxcore50",
       "dependencies": {
         "System.Collections": "4.0.11",
         "System.Threading": "4.0.11",
         "System.Threading.Tasks": "4.0.11",
-        "Newtonsoft.Json": "7.0.1",
         "System.Linq": "4.1.0"
       }
     }
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "7.0.1"
   }
 }

--- a/src/DotQuery.Extensions/project.json
+++ b/src/DotQuery.Extensions/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0-beta",
+  "version": "1.3.0-beta2",
   "description": "Extension libs and utilities of DotQuery, a lightweight query result caching framework for .NET",
   "packOptions": {
     "owners": [ "karldodd" ],
@@ -14,16 +14,21 @@
   },
   "copyright": "Copyright @  2013",
   "frameworks": {
+    "net451": {
+      "dependencies": {
+        "System.Net.Http": "4.0.0"
+      }
+    },
     "netstandard1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "DotQuery.Core": { "target": "project" },
         "System.Collections.Concurrent": "4.0.12",
         "System.Net.Http": "4.1.0"
       }
     }
   },
   "dependencies": {
+    "DotQuery.Core": { "target": "project" },
     "Microsoft.Extensions.Caching.Memory": "1.0.0"
   }
 }


### PR DESCRIPTION
Upgrade to 1.3.0-beta2
- Support .NETFramework 4.5.1
- Support .NETStandard 1.0
