### PR TITLE
Update TargetFramework to NetStandard2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/DotQuery.Core/DotQuery.Core.csproj
+++ b/src/DotQuery.Core/DotQuery.Core.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright ©  2013</Copyright>
     <AssemblyTitle>DotQuery.Core</AssemblyTitle>
     <VersionPrefix>1.4.0</VersionPrefix>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>DotQuery.Core</AssemblyName>
     <PackageId>DotQuery.Core</PackageId>

--- a/src/DotQuery.Core/DotQuery.Core.csproj
+++ b/src/DotQuery.Core/DotQuery.Core.csproj
@@ -10,7 +10,9 @@
     <AssemblyName>DotQuery.Core</AssemblyName>
     <PackageId>DotQuery.Core</PackageId>
     <PackageTags>dotquery;query;cache;memorycache;result;async</PackageTags>
-    <RepositoryType>git</RepositoryType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>    
     <RepositoryUrl>https://github.com/karldodd/DotQuery</RepositoryUrl>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>

--- a/src/DotQuery.Core/DotQuery.Core.csproj
+++ b/src/DotQuery.Core/DotQuery.Core.csproj
@@ -4,7 +4,7 @@
     <Description>Core libs of DotQuery, a lightweight query result caching framework for .NET</Description>
     <Copyright>Copyright ©  2013</Copyright>
     <AssemblyTitle>DotQuery.Core</AssemblyTitle>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>DotQuery.Core</AssemblyName>

--- a/src/DotQuery.Core/IAsyncQueryExecutor.cs
+++ b/src/DotQuery.Core/IAsyncQueryExecutor.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace DotQuery.Core
 {
     public interface IAsyncQueryExecutor<TQuery, TResult>
     {
-        Task<TResult> QueryAsync(TQuery query);
+        Task<TResult> QueryAsync(TQuery query, CancellationToken cancellationToken);
     }
 }

--- a/src/DotQuery.Core/Queries/AggregateAsyncQueryClientSideExecutor.cs
+++ b/src/DotQuery.Core/Queries/AggregateAsyncQueryClientSideExecutor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DotQuery.Core.Async;
 using DotQuery.Core.Caches;
@@ -31,7 +32,7 @@ namespace DotQuery.Core.Queries
             _mChildAsyncQueryExecutor = childAsyncQueryExecutor;
         }
 
-        protected override Task<List<TResult>> DoQueryAsync(AggregateQuery aq)
+        protected override Task<List<TResult>> DoQueryAsync(AggregateQuery aq, CancellationToken cancellationToken)
         {
             if (aq.ExportBinary)
             {
@@ -39,7 +40,7 @@ namespace DotQuery.Core.Queries
                 throw new NotSupportedException("AggregateQueryClientSideExecutor only handles client-side query aggreation");
             }
 
-            List<Task<TResult>> taskList = aq.Queries.Cast<TQuery>().Select(childQ => _mChildAsyncQueryExecutor.QueryAsync(childQ, EntryOptions.Default)).ToList(); //query all queries inside the Aggregated Query
+            List<Task<TResult>> taskList = aq.Queries.Cast<TQuery>().Select(childQ => _mChildAsyncQueryExecutor.QueryAsync(childQ, EntryOptions.Default, cancellationToken)).ToList(); //query all queries inside the Aggregated Query
             var queryList = aq.Queries.ToList();
 
             //Could use Task.WhenAll() instead if we don't want 'OnSingleQueryFinished' event

--- a/src/DotQuery.Extensions/DotQuery.Extensions.csproj
+++ b/src/DotQuery.Extensions/DotQuery.Extensions.csproj
@@ -4,7 +4,7 @@
     <Description>Extension libs and utilities of DotQuery, a lightweight query result caching framework for .NET</Description>
     <Copyright>Copyright @  2013</Copyright>
     <VersionPrefix>1.4.0</VersionPrefix>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>DotQuery.Extensions</AssemblyName>
     <PackageId>DotQuery.Extensions</PackageId>
     <PackageTags>dotquery;query;cache;result;async;extensions;webapi</PackageTags>

--- a/src/DotQuery.Extensions/DotQuery.Extensions.csproj
+++ b/src/DotQuery.Extensions/DotQuery.Extensions.csproj
@@ -10,6 +10,8 @@
     <PackageTags>dotquery;query;cache;result;async;extensions;webapi</PackageTags>
     <PackageProjectUrl>https://github.com/karldodd/DotQuery</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/karldodd/DotQuery</RepositoryUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -21,7 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotQuery.Core\DotQuery.Core.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
   </ItemGroup>
 

--- a/src/DotQuery.Extensions/DotQuery.Extensions.csproj
+++ b/src/DotQuery.Extensions/DotQuery.Extensions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Extension libs and utilities of DotQuery, a lightweight query result caching framework for .NET</Description>
     <Copyright>Copyright @  2013</Copyright>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>DotQuery.Extensions</AssemblyName>
     <PackageId>DotQuery.Extensions</PackageId>

--- a/src/DotQuery.Extensions/Http/WebApiQueryExecutorBase.cs
+++ b/src/DotQuery.Extensions/Http/WebApiQueryExecutorBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using DotQuery.Core;
 using DotQuery.Core.Async;
@@ -19,7 +20,7 @@ namespace DotQuery.Extensions.Http
             m_apiPath = apiPath;
         }
 
-        protected override async Task<TResult> DoQueryAsync(TQuery query)
+        protected override async Task<TResult> DoQueryAsync(TQuery query, CancellationToken cancellationToken)
         {
             var postBody = GetPostBody(query);
 

--- a/test/DotQuery.Core.Test/DotQuery.Core.Test.csproj
+++ b/test/DotQuery.Core.Test/DotQuery.Core.Test.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>DotQuery.Core.Test</AssemblyName>
     <PackageId>DotQuery.Core.Test</PackageId>
+    <IsPackable>false</IsPackable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/test/DotQuery.Core.Test/DotQuery.Core.Test.csproj
+++ b/test/DotQuery.Core.Test/DotQuery.Core.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>DotQuery.Core.Test Class Library</Description>
     <Copyright>Copyright ©  2013</Copyright>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>DotQuery.Core.Test</AssemblyName>
     <PackageId>DotQuery.Core.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/test/DotQuery.Core.Test/Stub/AddAsyncQueryExecutor.cs
+++ b/test/DotQuery.Core.Test/Stub/AddAsyncQueryExecutor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using DotQuery.Core.Async;
 using DotQuery.Core.Caches;
@@ -20,10 +21,13 @@ namespace DotQuery.Core.Test.Stub
         {
         }
 
-        protected override async Task<int> DoQueryAsync(AddQuery query)
+        protected override async Task<int> DoQueryAsync(AddQuery query, CancellationToken cancellationToken)
         {
             RealCalcCount++;
             await Task.Delay(m_delayTime);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
             checked
             {
                 return query.Left + query.Right;

--- a/test/DotQuery.Core.Test/TestAsyncMemoryCacheQueryExecutor.cs
+++ b/test/DotQuery.Core.Test/TestAsyncMemoryCacheQueryExecutor.cs
@@ -32,12 +32,12 @@ namespace DotQuery.Core.Test
             var query = new AddQuery { Left = 1, Right = 2 };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, CancellationToken.None)); })
                 <=
                 TimeSpan.FromMilliseconds(50), "Should hit cache");  //well, a cache hit
         }
@@ -53,17 +53,17 @@ namespace DotQuery.Core.Test
             var options = new EntryOptions { SlidingExpiration = TimeSpan.FromMinutes(1) };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 <=
                 TimeSpan.FromMilliseconds(50), "Should hit cache");  //well, a cache hit
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, CancellationToken.None)); })
                 <=
                 TimeSpan.FromMilliseconds(50), "Should hit cache");  //well, a cache hit
         }
@@ -77,12 +77,12 @@ namespace DotQuery.Core.Test
             var query = new AddQuery { Left = 1, Right = 2 };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, EntryOptions.Empty)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, EntryOptions.Empty, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, EntryOptions.Empty)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, EntryOptions.Empty, CancellationToken.None)); })
                 >=
                 delayTime);
         }
@@ -96,17 +96,17 @@ namespace DotQuery.Core.Test
             var query = new AddQuery { Left = 1, Right = 2 };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, EntryOptions.Default)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, EntryOptions.Default, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, EntryOptions.Default)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, EntryOptions.Default, CancellationToken.None)); })
                 <=
                 TimeSpan.FromMilliseconds(50), "Should hit cache");  //well, a cache hit
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, CancellationToken.None)); })
                 <=
                 TimeSpan.FromMilliseconds(50), "Should hit cache");  //well, a cache hit
         }
@@ -122,12 +122,12 @@ namespace DotQuery.Core.Test
             var options = new EntryOptions();
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 <=
                 TimeSpan.FromMilliseconds(50), "Should hit cache");  //well, a cache hit
         }
@@ -143,14 +143,14 @@ namespace DotQuery.Core.Test
             var options = new EntryOptions { SlidingExpiration = TimeSpan.FromMilliseconds(1) };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Thread.Sleep(1);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
         }
@@ -166,14 +166,14 @@ namespace DotQuery.Core.Test
             var options = new EntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMilliseconds(1) };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Thread.Sleep(1);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
         }
@@ -189,14 +189,14 @@ namespace DotQuery.Core.Test
             var options = new EntryOptions { AbsoluteExpiration = DateTimeOffset.Now.AddMilliseconds(1) };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Thread.Sleep(1);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
         }
@@ -211,8 +211,8 @@ namespace DotQuery.Core.Test
             //use cached failed task
             var q2 = new AddQuery { Left = int.MaxValue, Right = int.MaxValue };
 
-            Assert.True(TryCatchException<OverflowException>(() => TimeCost(async () => { await executor.QueryAsync(q1); })));
-            Assert.True(TryCatchException<OverflowException>(() => TimeCost(async () => { await executor.QueryAsync(q2, new EntryOptions { Behaviors = (EntryBehaviors)(EntryBehaviors.Default - EntryBehaviors.ReQueryWhenErrorCached) }); })));
+            Assert.True(TryCatchException<OverflowException>(() => TimeCost(async () => { await executor.QueryAsync(q1, CancellationToken.None); })));
+            Assert.True(TryCatchException<OverflowException>(() => TimeCost(async () => { await executor.QueryAsync(q2, new EntryOptions { Behaviors = (EntryBehaviors)(EntryBehaviors.Default - EntryBehaviors.ReQueryWhenErrorCached) }, CancellationToken.None); })));
 
             Assert.Equal(1, executor.RealCalcCount);
         }
@@ -228,12 +228,12 @@ namespace DotQuery.Core.Test
             var options = new EntryOptions { SlidingExpiration = TimeSpan.FromMinutes(1) };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 <=
                 TimeSpan.FromMilliseconds(50), "Should hit cache");  //well, a cache hit
         }
@@ -249,12 +249,12 @@ namespace DotQuery.Core.Test
             var options = new EntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1) };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 <=
                 TimeSpan.FromMilliseconds(50), "Should hit cache");  //well, a cache hit
         }
@@ -270,14 +270,39 @@ namespace DotQuery.Core.Test
             var options = new EntryOptions { AbsoluteExpiration = DateTimeOffset.Now.AddMinutes(1) };
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 >=
                 delayTime);
 
             Assert.True(
-                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options)); })
+                TimeCost(async () => { Assert.Equal(3, await executor.QueryAsync(query, options, CancellationToken.None)); })
                 <=
                 TimeSpan.FromMilliseconds(50), "Should hit cache");  //well, a cache hit
+        }
+
+        [Fact]
+        public async Task TestCancellationTokenAsync()
+        {
+            var delayTime = TimeSpan.FromMilliseconds(100);
+            var executor = CreateMemoryExecutor(delayTime);
+
+            var query = new AddQuery { Left = 1, Right = 2 };
+
+            using (var cts = new CancellationTokenSource())
+            {
+                cts.CancelAfter(TimeSpan.FromMilliseconds(1));
+
+                try
+                {
+                    await executor.QueryAsync(query, cts.Token);
+                }
+                catch (Exception ex)
+                {
+                    var ocex = ex as OperationCanceledException;
+
+                    Assert.NotNull(ocex);
+                }
+            }
         }
 
         private static AddAsyncQueryExecutor CreateMemoryExecutor(TimeSpan delayTime)


### PR DESCRIPTION
- Update TargetFramework to NetStandard2.0
-  Change IAsyncQueryExecutor.QueryAsync(TQuery) to IAsyncQueryExecutor.QueryAsync(TQuery, CancellationToken)
- Update version from 1.4.0 to 2.0.0
- Add MIT LICENSE